### PR TITLE
replace `skip_while` with `filter`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -224,7 +224,7 @@ impl PafFile {
         //println!("{}", line);
         let mut cigars = line
             .split('\t')
-            .skip_while(|s| !s.starts_with("cg:Z:"))
+            .filter(|s| s.starts_with("cg:Z:"))
             .map(|s| s.strip_prefix("cg:Z:").unwrap())
             .collect::<Vec<&str>>();
 


### PR DESCRIPTION
This avoids silly errors (as in https://github.com/AndreaGuarracino/paf2chain/issues/1) when the `cg:Z:` tag is not the last one in the PAF lines.